### PR TITLE
chore(docs): replace absolute demo URLs with relative paths in nav config

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -33,10 +33,10 @@ export default defineConfig({
       {
         text: 'Demos',
         items: [
-          { text: 'React Web', link: 'https://devitools.github.io/ybyra/demo/react-web/', target: '_blank' },
-          { text: 'React Native', link: 'https://devitools.github.io/ybyra/demo/react-native/', target: '_blank' },
-          { text: 'Vue + Quasar', link: 'https://devitools.github.io/ybyra/demo/vue-quasar/', target: '_blank' },
-          { text: 'SvelteKit', link: 'https://devitools.github.io/ybyra/demo/sveltekit/', target: '_blank' },
+          { text: 'React Web', link: '/demo/react-web/', target: '_blank' },
+          { text: 'React Native', link: '/demo/react-native/', target: '_blank' },
+          { text: 'Vue + Quasar', link: '/demo/vue-quasar/', target: '_blank' },
+          { text: 'SvelteKit', link: '/demo/sveltekit/', target: '_blank' },
         ],
       },
     ],


### PR DESCRIPTION
## Description

Simplify demo nav links in VitePress config

Replace hardcoded absolute URLs with relative paths in the Demos navigation menu.

Before:  `https://devitools.github.io/ybyra/demo/react-web/`
After:  /demo/react-web/ 

VitePress automatically prepends  base: '/ybyra/'  to  / -prefixed links, producing the correct final URL. This makes the config environment-agnostic and removes the hardcoded domain dependency.

No behavior change in production.  target: '_blank'  is preserved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated demo navigation links to use internal routes instead of external URLs, improving navigation efficiency while maintaining the same user experience with links opening in new tabs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->