### PR TITLE
feat(renderers): add currency/file renderers, filler generators, and list sub-schema modal

### DIFF
--- a/packages/core/src/fields/list.ts
+++ b/packages/core/src/fields/list.ts
@@ -7,7 +7,7 @@ export class ListFieldDefinition extends FieldDefinition<Record<string, unknown>
   }
 
   itemSchema(schema: SchemaDefinition<any>): this {
-    this._config.attrs = { ...this._config.attrs, itemSchema: schema }
+    this._config.attrs = { ...this._config.attrs, itemSchema: schema.provide() }
     return this
   }
 

--- a/packages/core/src/filler.test.ts
+++ b/packages/core/src/filler.test.ts
@@ -150,6 +150,56 @@ describe('defaultFillers', () => {
     const value = defaultFillers.checkbox(makeFieldConfig({ component: 'checkbox' }))
     expect(value).toBeTypeOf('boolean')
   })
+
+  it('generates password for text with password kind', () => {
+    const value = defaultFillers.text(makeFieldConfig({ component: 'text', kind: 'password' }))
+    expect(value).toBeTypeOf('string')
+    expect((value as string).length).toBeGreaterThanOrEqual(8)
+  })
+
+  it('generates paragraph for textarea', () => {
+    const value = defaultFillers.textarea(makeFieldConfig({ component: 'textarea' }))
+    expect(value).toBeTypeOf('string')
+    expect((value as string).length).toBeGreaterThan(10)
+  })
+
+  it('generates time string for time', () => {
+    const value = defaultFillers.time(makeFieldConfig({ component: 'time' }))
+    expect(value).toBeTypeOf('string')
+    expect(value as string).toMatch(/^\d{2}:\d{2}$/)
+  })
+
+  it('generates value from options for select', () => {
+    const value = defaultFillers.select(makeFieldConfig({
+      component: 'select',
+      attrs: { options: ['a', 'b', 'c'] },
+    }))
+    expect(['a', 'b', 'c']).toContain(value)
+  })
+
+  it('returns undefined for select without options', () => {
+    const value = defaultFillers.select(makeFieldConfig({ component: 'select' }))
+    expect(value).toBeUndefined()
+  })
+
+  it('generates subset of options for multiselect', () => {
+    const value = defaultFillers.multiselect(makeFieldConfig({
+      component: 'multiselect',
+      attrs: { options: ['a', 'b', 'c', 'd'] },
+    }))
+    expect(Array.isArray(value)).toBe(true)
+    const arr = value as string[]
+    expect(arr.length).toBeGreaterThanOrEqual(1)
+    expect(arr.length).toBeLessThanOrEqual(3)
+    for (const item of arr) {
+      expect(['a', 'b', 'c', 'd']).toContain(item)
+    }
+  })
+
+  it('returns empty array for multiselect without options', () => {
+    const value = defaultFillers.multiselect(makeFieldConfig({ component: 'multiselect' }))
+    expect(value).toEqual([])
+  })
 })
 
 describe('fill', () => {

--- a/packages/core/src/filler.ts
+++ b/packages/core/src/filler.ts
@@ -8,6 +8,7 @@ export type FillerRegistry = Record<string, FillerFn>
 const textKindGenerators: Record<string, () => string> = {
   email: () => faker.internet.email(),
   phone: () => faker.phone.number(),
+  password: () => faker.internet.password({ length: 12 }),
   cpf: () => faker.string.numeric({ length: 11, allowLeadingZeros: true }).replace(/(\d{3})(\d{3})(\d{3})(\d{2})/, '$1.$2.$3-$4'),
   cnpj: () => faker.string.numeric({ length: 14, allowLeadingZeros: true }).replace(/(\d{2})(\d{3})(\d{3})(\d{4})(\d{2})/, '$1.$2.$3/$4-$5'),
   cep: () => faker.location.zipCode(),
@@ -43,6 +44,31 @@ export const defaultFillers: FillerRegistry = {
   },
   checkbox() {
     return faker.datatype.boolean()
+  },
+  textarea() {
+    return faker.lorem.paragraph()
+  },
+  time() {
+    const hour = faker.number.int({ min: 0, max: 23 }).toString().padStart(2, '0')
+    const minute = faker.number.int({ min: 0, max: 59 }).toString().padStart(2, '0')
+    return `${hour}:${minute}`
+  },
+  select(config) {
+    const options = (config.attrs.options ?? []) as (string | number)[]
+    if (options.length === 0) return undefined
+    return faker.helpers.arrayElement(options)
+  },
+  multiselect(config) {
+    const options = (config.attrs.options ?? []) as (string | number)[]
+    if (options.length === 0) return []
+    const count = faker.number.int({ min: 1, max: Math.min(3, options.length) })
+    return faker.helpers.arrayElements(options, count)
+  },
+  file() {
+    return undefined
+  },
+  image() {
+    return undefined
   },
 }
 

--- a/packages/react-native/src/renderers/CurrencyField.tsx
+++ b/packages/react-native/src/renderers/CurrencyField.tsx
@@ -1,0 +1,95 @@
+import { View, Text, TextInput, StyleSheet } from "react-native";
+import { useTranslation } from "react-i18next";
+import type { FieldRendererProps } from "@ybyra/react";
+import { useTheme } from "../theme/context";
+import type { Theme } from "../theme/default";
+import { ds } from "../support/ds";
+
+export function CurrencyField({ domain, name, value, config, proxy, errors, onChange, onBlur, onFocus }: FieldRendererProps) {
+  const { t } = useTranslation();
+  const theme = useTheme();
+  const styles = createStyles(theme);
+  if (proxy.hidden) return null;
+
+  const fieldLabel = t(`${domain}.fields.${name}`, { defaultValue: name });
+  const prefix = (config.attrs.prefix as string) ?? "";
+
+  return (
+    <View style={styles.container} {...ds(`CurrencyField:${name}`)}>
+      <Text style={styles.label}>{fieldLabel}</Text>
+      <View style={styles.inputWrapper}>
+        {prefix ? <Text style={styles.prefix}>{prefix}</Text> : null}
+        <TextInput
+          style={[styles.input, prefix ? styles.inputWithPrefix : null, proxy.disabled && styles.inputDisabled, errors.length > 0 && styles.inputError]}
+          value={value !== undefined && value !== null ? String(value) : ""}
+          onChangeText={(text) => {
+            const num = Number(text);
+            onChange(isNaN(num) ? text : num);
+          }}
+          onBlur={onBlur}
+          onFocus={onFocus}
+          editable={!proxy.disabled}
+          keyboardType="decimal-pad"
+          placeholderTextColor={theme.colors.mutedForeground}
+        />
+      </View>
+      <View style={styles.errorSlot}>
+        {errors.map((error, i) => (
+          <Text key={i} style={styles.error}>{error}</Text>
+        ))}
+      </View>
+    </View>
+  );
+}
+
+const createStyles = (theme: Theme) => StyleSheet.create({
+  container: {
+    paddingHorizontal: theme.spacing.xs,
+  },
+  label: {
+    fontSize: theme.fontSize.sm,
+    fontWeight: theme.fontWeight.semibold,
+    marginBottom: theme.spacing.xs,
+    color: theme.colors.foreground,
+  },
+  inputWrapper: {
+    flexDirection: "row",
+    alignItems: "center",
+  },
+  prefix: {
+    position: "absolute",
+    left: theme.spacing.md,
+    fontSize: theme.fontSize.md,
+    color: theme.colors.mutedForeground,
+    zIndex: 1,
+  },
+  input: {
+    flex: 1,
+    borderWidth: 1,
+    borderColor: theme.colors.input,
+    borderRadius: theme.borderRadius.md,
+    paddingHorizontal: theme.spacing.md,
+    paddingVertical: 10,
+    fontSize: theme.fontSize.md,
+    backgroundColor: theme.colors.card,
+    color: theme.colors.cardForeground,
+  },
+  inputWithPrefix: {
+    paddingLeft: 36,
+  },
+  inputDisabled: {
+    backgroundColor: theme.colors.muted,
+    color: theme.colors.mutedForeground,
+  },
+  inputError: {
+    borderColor: theme.colors.destructive,
+  },
+  errorSlot: {
+    minHeight: 20,
+    marginTop: 2,
+  },
+  error: {
+    fontSize: theme.fontSize.xs,
+    color: theme.colors.destructive,
+  },
+});

--- a/packages/react-native/src/renderers/FileField.tsx
+++ b/packages/react-native/src/renderers/FileField.tsx
@@ -1,0 +1,90 @@
+import { View, Text, Pressable, StyleSheet } from "react-native";
+import { useTranslation } from "react-i18next";
+import type { FieldRendererProps } from "@ybyra/react";
+import { useTheme } from "../theme/context";
+import type { Theme } from "../theme/default";
+import { ds } from "../support/ds";
+
+export function FileField({ domain, name, value, config, proxy, errors }: FieldRendererProps) {
+  const { t } = useTranslation();
+  const theme = useTheme();
+  const styles = createStyles(theme);
+  if (proxy.hidden) return null;
+
+  const fieldLabel = t(`${domain}.fields.${name}`, { defaultValue: name });
+  const isImage = config.component === "image";
+  const fileName = value && typeof value === "object" && "name" in value ? String(value.name) : (value ? String(value) : "");
+
+  return (
+    <View style={styles.container} {...ds(`FileField:${name}`)}>
+      <Text style={styles.label}>{fieldLabel}</Text>
+      <View style={styles.inputWrapper}>
+        {/* TODO: integrate expo-document-picker or react-native-document-picker for actual file selection */}
+        <Pressable
+          style={[styles.chooseBtn, proxy.disabled && styles.chooseBtnDisabled]}
+          disabled={proxy.disabled}
+        >
+          <Text style={[styles.chooseBtnText, proxy.disabled && styles.chooseBtnTextDisabled]}>
+            {t("common.file.choose", { defaultValue: isImage ? "Choose image…" : "Choose file…" })}
+          </Text>
+        </Pressable>
+        <Text style={styles.fileName} numberOfLines={1}>
+          {fileName || t("common.file.none", { defaultValue: "No file selected" })}
+        </Text>
+      </View>
+      <View style={styles.errorSlot}>
+        {errors.map((error, i) => (
+          <Text key={i} style={styles.error}>{error}</Text>
+        ))}
+      </View>
+    </View>
+  );
+}
+
+const createStyles = (theme: Theme) => StyleSheet.create({
+  container: {
+    paddingHorizontal: theme.spacing.xs,
+  },
+  label: {
+    fontSize: theme.fontSize.sm,
+    fontWeight: theme.fontWeight.semibold,
+    marginBottom: theme.spacing.xs,
+    color: theme.colors.foreground,
+  },
+  inputWrapper: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: theme.spacing.sm,
+  },
+  chooseBtn: {
+    borderWidth: 1,
+    borderColor: theme.colors.input,
+    borderRadius: theme.borderRadius.md,
+    paddingHorizontal: theme.spacing.md,
+    paddingVertical: 8,
+    backgroundColor: theme.colors.secondary,
+  },
+  chooseBtnDisabled: {
+    backgroundColor: theme.colors.muted,
+  },
+  chooseBtnText: {
+    fontSize: theme.fontSize.sm,
+    color: theme.colors.secondaryForeground,
+  },
+  chooseBtnTextDisabled: {
+    color: theme.colors.mutedForeground,
+  },
+  fileName: {
+    flex: 1,
+    fontSize: theme.fontSize.sm,
+    color: theme.colors.mutedForeground,
+  },
+  errorSlot: {
+    minHeight: 20,
+    marginTop: 2,
+  },
+  error: {
+    fontSize: theme.fontSize.xs,
+    color: theme.colors.destructive,
+  },
+});

--- a/packages/react-native/src/renderers/ListField.tsx
+++ b/packages/react-native/src/renderers/ListField.tsx
@@ -1,26 +1,113 @@
-import { View, Text, Pressable, StyleSheet } from "react-native";
+import { useState, useMemo } from "react";
+import { View, Text, Pressable, Modal, ScrollView, StyleSheet } from "react-native";
 import { useTranslation } from "react-i18next";
 import type { FieldRendererProps } from "@ybyra/react";
+import { getRenderer, useDataForm } from "@ybyra/react";
+import type { SchemaProvide, Scope } from "@ybyra/core";
 import { useTheme } from "../theme/context";
 import type { Theme } from "../theme/default";
 import { ds } from "../support/ds";
 
-export function ListField({ domain, name, value, config, proxy, errors, onChange }: FieldRendererProps) {
+function ItemFormModal({
+  itemSchema,
+  scope,
+  initialValues,
+  onSave,
+  onCancel,
+  theme,
+}: {
+  itemSchema: SchemaProvide;
+  scope: string;
+  initialValues?: Record<string, unknown>;
+  onSave: (values: Record<string, unknown>) => void;
+  onCancel: () => void;
+  theme: Theme;
+}) {
+  const { t } = useTranslation();
+  const modalStyles = createModalStyles(theme);
+
+  const noopComponent = useMemo(() => ({
+    scope: scope as typeof Scope[keyof typeof Scope],
+    scopes: {} as Record<string, { path: string }>,
+    reload: () => {},
+    navigator: { push: () => {}, back: () => {}, replace: () => {} },
+    dialog: { confirm: async () => true, alert: async () => {} },
+    toast: { success: () => {}, error: () => {}, warning: () => {}, info: () => {} },
+    loading: { show: () => {}, hide: () => {} },
+  }), [scope]);
+
+  const form = useDataForm({
+    schema: itemSchema,
+    scope: scope as typeof Scope[keyof typeof Scope],
+    component: noopComponent,
+    initialValues,
+  });
+
+  const handleSave = () => {
+    if (form.validate()) {
+      onSave(form.state);
+    }
+  };
+
+  return (
+    <Modal transparent visible animationType="fade" onRequestClose={onCancel}>
+      <Pressable style={modalStyles.overlay} onPress={onCancel}>
+        <Pressable style={modalStyles.card} onPress={() => {}}>
+          <Text style={modalStyles.title}>
+            {initialValues ? t("common.list.editItem", { defaultValue: "Edit item" }) : t("common.list.addItem", { defaultValue: "Add item" })}
+          </Text>
+          <ScrollView style={modalStyles.body}>
+            {form.fields.map((field) => {
+              if (field.proxy.hidden) return null;
+              const Renderer = getRenderer(field.config.component);
+              if (!Renderer) return null;
+              return (
+                <View key={field.name}>
+                  <Renderer {...form.getFieldProps(field.name)} />
+                </View>
+              );
+            })}
+          </ScrollView>
+          <View style={modalStyles.actions}>
+            <Pressable style={[modalStyles.button, modalStyles.cancelButton]} onPress={onCancel}>
+              <Text style={modalStyles.cancelText}>{t("common.dialog.cancel", { defaultValue: "Cancel" })}</Text>
+            </Pressable>
+            <Pressable style={[modalStyles.button, modalStyles.okButton]} onPress={handleSave}>
+              <Text style={modalStyles.okText}>{t("common.dialog.ok", { defaultValue: "OK" })}</Text>
+            </Pressable>
+          </View>
+        </Pressable>
+      </Pressable>
+    </Modal>
+  );
+}
+
+export function ListField({ domain, name, value, config, proxy, errors, onChange, scope }: FieldRendererProps) {
   const { t } = useTranslation();
   const theme = useTheme();
   const styles = createStyles(theme);
+  const [editIndex, setEditIndex] = useState<number | null>(null);
+  const [showAdd, setShowAdd] = useState(false);
   if (proxy.hidden) return null;
 
   const fieldLabel = t(`${domain}.fields.${name}`, { defaultValue: name });
   const items = Array.isArray(value) ? (value as Record<string, unknown>[]) : [];
   const reorderable = config.attrs.reorderable === true;
+  const rawSchema = config.attrs.itemSchema;
+  const itemSchema = rawSchema && typeof rawSchema === 'object' && 'fields' in rawSchema && 'domain' in rawSchema
+    ? (rawSchema as SchemaProvide)
+    : undefined;
 
   const remove = (index: number) => {
     onChange(items.filter((_, i) => i !== index));
   };
 
   const add = () => {
-    onChange([...items, {}]);
+    if (itemSchema) {
+      setShowAdd(true);
+    } else {
+      onChange([...items, {}]);
+    }
   };
 
   const moveUp = (index: number) => {
@@ -37,6 +124,19 @@ export function ListField({ domain, name, value, config, proxy, errors, onChange
     onChange(next);
   };
 
+  const handleSaveNew = (values: Record<string, unknown>) => {
+    onChange([...items, values]);
+    setShowAdd(false);
+  };
+
+  const handleSaveEdit = (values: Record<string, unknown>) => {
+    if (editIndex === null) return;
+    const next = [...items];
+    next[editIndex] = values;
+    onChange(next);
+    setEditIndex(null);
+  };
+
   return (
     <View style={styles.container} {...ds(`ListField:${name}`)}>
       <Text style={styles.label}>{fieldLabel}</Text>
@@ -48,6 +148,11 @@ export function ListField({ domain, name, value, config, proxy, errors, onChange
               {Object.values(item).filter(Boolean).join(", ") || "—"}
             </Text>
             <View style={styles.rowActions}>
+              {itemSchema && !proxy.disabled && (
+                <Pressable onPress={() => setEditIndex(index)}>
+                  <Text style={styles.btnText}>✎</Text>
+                </Pressable>
+              )}
               {reorderable && (
                 <>
                   <Pressable onPress={() => moveUp(index)} disabled={proxy.disabled || index === 0}>
@@ -77,6 +182,28 @@ export function ListField({ domain, name, value, config, proxy, errors, onChange
           <Text key={i} style={styles.error}>{error}</Text>
         ))}
       </View>
+
+      {showAdd && itemSchema && (
+        <ItemFormModal
+          itemSchema={itemSchema}
+          scope={scope}
+          onSave={handleSaveNew}
+          onCancel={() => setShowAdd(false)}
+          theme={theme}
+        />
+      )}
+
+      {editIndex !== null && itemSchema && (
+        <ItemFormModal
+          key={editIndex}
+          itemSchema={itemSchema}
+          scope={scope}
+          initialValues={items[editIndex]}
+          onSave={handleSaveEdit}
+          onCancel={() => setEditIndex(null)}
+          theme={theme}
+        />
+      )}
     </View>
   );
 }
@@ -152,5 +279,64 @@ const createStyles = (theme: Theme) => StyleSheet.create({
   error: {
     fontSize: theme.fontSize.xs,
     color: theme.colors.destructive,
+  },
+});
+
+const createModalStyles = (theme: Theme) => StyleSheet.create({
+  overlay: {
+    flex: 1,
+    backgroundColor: "rgba(0, 0, 0, 0.5)",
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  card: {
+    backgroundColor: theme.colors.card,
+    borderRadius: theme.borderRadius.xl,
+    padding: theme.spacing.xxl,
+    minWidth: 360,
+    maxWidth: 480,
+    maxHeight: "80%",
+    shadowColor: "#000",
+    shadowOffset: { width: 0, height: 4 },
+    shadowOpacity: 0.15,
+    shadowRadius: 12,
+    elevation: 8,
+  },
+  title: {
+    fontSize: theme.fontSize.lg,
+    fontWeight: theme.fontWeight.semibold,
+    color: theme.colors.foreground,
+    marginBottom: theme.spacing.md,
+  },
+  body: {
+    marginBottom: theme.spacing.xl,
+  },
+  actions: {
+    flexDirection: "row",
+    justifyContent: "flex-end",
+    gap: theme.spacing.sm,
+  },
+  button: {
+    paddingVertical: theme.spacing.sm,
+    paddingHorizontal: theme.spacing.lg,
+    borderRadius: theme.borderRadius.md,
+    minWidth: 80,
+    alignItems: "center",
+  },
+  cancelButton: {
+    backgroundColor: theme.colors.secondary,
+  },
+  cancelText: {
+    fontSize: theme.fontSize.sm,
+    fontWeight: theme.fontWeight.medium,
+    color: theme.colors.secondaryForeground,
+  },
+  okButton: {
+    backgroundColor: theme.colors.primary,
+  },
+  okText: {
+    fontSize: theme.fontSize.sm,
+    fontWeight: theme.fontWeight.medium,
+    color: theme.colors.primaryForeground,
   },
 });

--- a/packages/react-native/src/renderers/index.ts
+++ b/packages/react-native/src/renderers/index.ts
@@ -9,6 +9,8 @@ import { SelectField } from "./SelectField";
 import { MultiSelectField } from "./MultiSelectField";
 import { ListField } from "./ListField";
 import { TreeField } from "./TreeField";
+import { CurrencyField } from "./CurrencyField";
+import { FileField } from "./FileField";
 
 registerRenderers({
   text: TextField,
@@ -23,4 +25,7 @@ registerRenderers({
   multiselect: MultiSelectField,
   list: ListField,
   tree: TreeField,
+  currency: CurrencyField,
+  file: FileField,
+  image: FileField,
 });

--- a/packages/react-web/src/renderers/CurrencyField.tsx
+++ b/packages/react-web/src/renderers/CurrencyField.tsx
@@ -1,0 +1,110 @@
+import { useTranslation } from "react-i18next";
+import type { FieldRendererProps } from "@ybyra/react";
+import { useTheme } from "../theme/context";
+import type { Theme } from "../theme/default";
+import { ds } from "../support/ds";
+
+export function CurrencyField({ domain, name, value, config, proxy, errors, onChange, onBlur, onFocus }: FieldRendererProps) {
+  const { t } = useTranslation();
+  const theme = useTheme();
+  const styles = createStyles(theme);
+  if (proxy.hidden) return null;
+
+  const fieldLabel = t(`${domain}.fields.${name}`, { defaultValue: name });
+  const hasError = errors.length > 0;
+  const prefix = (config.attrs.prefix as string) ?? "";
+  const precision = (config.attrs.precision as number) ?? 2;
+  const step = precision > 0 ? (1 / Math.pow(10, precision)).toString() : "1";
+
+  return (
+    <div style={styles.container} {...ds(`CurrencyField:${name}`)}>
+      <label style={{ ...styles.label, ...(hasError ? styles.labelError : {}) }}>{fieldLabel}</label>
+      <div style={styles.inputWrapper}>
+        {prefix && <span style={styles.prefix}>{prefix}</span>}
+        <input
+          type="number"
+          step={step}
+          style={{
+            ...styles.input,
+            ...(prefix ? styles.inputWithPrefix : {}),
+            ...(proxy.disabled ? styles.inputDisabled : {}),
+            ...(hasError ? styles.inputError : {}),
+          }}
+          value={value !== undefined && value !== null ? String(value) : ""}
+          onChange={(e) => {
+            const num = Number(e.target.value);
+            onChange(isNaN(num) ? e.target.value : num);
+          }}
+          onBlur={onBlur}
+          onFocus={onFocus}
+          disabled={proxy.disabled}
+        />
+      </div>
+      <div style={styles.errorSlot}>
+        {errors.map((error, i) => (
+          <p key={i} style={styles.error}>{error}</p>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+const createStyles = (theme: Theme) => ({
+  container: {
+    padding: `0 ${theme.spacing.xs}px`,
+  },
+  label: {
+    display: "block",
+    fontSize: theme.fontSize.sm,
+    fontWeight: theme.fontWeight.semibold,
+    marginBottom: theme.spacing.xs,
+    color: theme.colors.foreground,
+  },
+  labelError: {
+    color: theme.colors.destructive,
+  },
+  inputWrapper: {
+    position: "relative" as const,
+    display: "flex",
+    alignItems: "center",
+  },
+  prefix: {
+    position: "absolute" as const,
+    left: theme.spacing.md,
+    fontSize: theme.fontSize.md,
+    color: theme.colors.mutedForeground,
+    pointerEvents: "none" as const,
+  },
+  input: {
+    display: "block",
+    width: "100%",
+    boxSizing: "border-box" as const,
+    border: `1px solid ${theme.colors.input}`,
+    borderRadius: theme.borderRadius.md,
+    padding: `10px ${theme.spacing.md}px`,
+    fontSize: theme.fontSize.md,
+    backgroundColor: theme.colors.card,
+    color: theme.colors.cardForeground,
+    fontFamily: "inherit",
+    outline: "none",
+  },
+  inputWithPrefix: {
+    paddingLeft: 36,
+  },
+  inputDisabled: {
+    backgroundColor: theme.colors.muted,
+    color: theme.colors.mutedForeground,
+  },
+  inputError: {
+    borderColor: theme.colors.destructive,
+  },
+  errorSlot: {
+    minHeight: 20,
+    marginTop: 2,
+  },
+  error: {
+    fontSize: theme.fontSize.xs,
+    color: theme.colors.destructive,
+    margin: 0,
+  },
+});

--- a/packages/react-web/src/renderers/FileField.tsx
+++ b/packages/react-web/src/renderers/FileField.tsx
@@ -1,0 +1,128 @@
+import { useRef, useMemo, useEffect } from "react";
+import { useTranslation } from "react-i18next";
+import type { FieldRendererProps } from "@ybyra/react";
+import { useTheme } from "../theme/context";
+import type { Theme } from "../theme/default";
+import { ds } from "../support/ds";
+
+export function FileField({ domain, name, value, config, proxy, errors, onChange }: FieldRendererProps) {
+  const { t } = useTranslation();
+  const theme = useTheme();
+  const styles = createStyles(theme);
+  const inputRef = useRef<HTMLInputElement>(null);
+  if (proxy.hidden) return null;
+
+  const fieldLabel = t(`${domain}.fields.${name}`, { defaultValue: name });
+  const hasError = errors.length > 0;
+  const accept = (config.attrs.accept as string) ?? undefined;
+  const isImage = config.component === "image";
+  const fileName = value instanceof File ? value.name : (value ? String(value) : "");
+
+  const previewUrl = useMemo(() => {
+    if (value instanceof File && isImage) return URL.createObjectURL(value);
+    return null;
+  }, [value, isImage]);
+
+  useEffect(() => {
+    return () => { if (previewUrl) URL.revokeObjectURL(previewUrl); };
+  }, [previewUrl]);
+
+  return (
+    <div style={styles.container} {...ds(`FileField:${name}`)}>
+      <label style={{ ...styles.label, ...(hasError ? styles.labelError : {}) }}>{fieldLabel}</label>
+      <div style={styles.inputWrapper}>
+        <button
+          type="button"
+          style={{ ...styles.chooseBtn, ...(proxy.disabled ? styles.chooseBtnDisabled : {}) }}
+          onClick={() => inputRef.current?.click()}
+          disabled={proxy.disabled}
+        >
+          {t("common.file.choose", { defaultValue: isImage ? "Choose image…" : "Choose file…" })}
+        </button>
+        <span style={styles.fileName}>{fileName || t("common.file.none", { defaultValue: "No file selected" })}</span>
+        <input
+          ref={inputRef}
+          type="file"
+          accept={accept ?? (isImage ? "image/*" : undefined)}
+          style={{ display: "none" }}
+          onChange={(e) => {
+            const file = e.target.files?.[0];
+            onChange(file ?? null);
+          }}
+          disabled={proxy.disabled}
+        />
+      </div>
+      {previewUrl && (
+        <img
+          src={previewUrl}
+          alt={fileName}
+          style={styles.preview}
+        />
+      )}
+      <div style={styles.errorSlot}>
+        {errors.map((error, i) => (
+          <p key={i} style={styles.error}>{error}</p>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+const createStyles = (theme: Theme) => ({
+  container: {
+    padding: `0 ${theme.spacing.xs}px`,
+  },
+  label: {
+    display: "block",
+    fontSize: theme.fontSize.sm,
+    fontWeight: theme.fontWeight.semibold,
+    marginBottom: theme.spacing.xs,
+    color: theme.colors.foreground,
+  },
+  labelError: {
+    color: theme.colors.destructive,
+  },
+  inputWrapper: {
+    display: "flex",
+    alignItems: "center",
+    gap: theme.spacing.sm,
+  },
+  chooseBtn: {
+    border: `1px solid ${theme.colors.input}`,
+    borderRadius: theme.borderRadius.md,
+    padding: `8px ${theme.spacing.md}px`,
+    fontSize: theme.fontSize.sm,
+    backgroundColor: theme.colors.secondary,
+    color: theme.colors.secondaryForeground,
+    cursor: "pointer",
+    whiteSpace: "nowrap" as const,
+  },
+  chooseBtnDisabled: {
+    backgroundColor: theme.colors.muted,
+    color: theme.colors.mutedForeground,
+    cursor: "default",
+  },
+  fileName: {
+    fontSize: theme.fontSize.sm,
+    color: theme.colors.mutedForeground,
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap" as const,
+  },
+  preview: {
+    marginTop: theme.spacing.sm,
+    maxWidth: 200,
+    maxHeight: 150,
+    borderRadius: theme.borderRadius.md,
+    objectFit: "cover" as const,
+  },
+  errorSlot: {
+    minHeight: 20,
+    marginTop: 2,
+  },
+  error: {
+    fontSize: theme.fontSize.xs,
+    color: theme.colors.destructive,
+    margin: 0,
+  },
+});

--- a/packages/react-web/src/renderers/ListField.tsx
+++ b/packages/react-web/src/renderers/ListField.tsx
@@ -1,28 +1,114 @@
-import { useState } from "react";
+import { useState, useMemo } from "react";
+import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
 import type { FieldRendererProps } from "@ybyra/react";
+import { getRenderer, useDataForm } from "@ybyra/react";
+import type { SchemaProvide, Scope } from "@ybyra/core";
 import { useTheme } from "../theme/context";
 import type { Theme } from "../theme/default";
 import { ds } from "../support/ds";
 
-export function ListField({ domain, name, value, config, proxy, errors, onChange }: FieldRendererProps) {
+function ItemFormModal({
+  itemSchema,
+  scope,
+  initialValues,
+  onSave,
+  onCancel,
+}: {
+  itemSchema: SchemaProvide;
+  scope: string;
+  initialValues?: Record<string, unknown>;
+  onSave: (values: Record<string, unknown>) => void;
+  onCancel: () => void;
+}) {
+  const { t } = useTranslation();
+  const theme = useTheme();
+  const modalStyles = createModalStyles(theme);
+
+  const noopComponent = useMemo(() => ({
+    scope: scope as typeof Scope[keyof typeof Scope],
+    scopes: {} as Record<string, { path: string }>,
+    reload: () => {},
+    navigator: { push: () => {}, back: () => {}, replace: () => {} },
+    dialog: { confirm: async () => true, alert: async () => {} },
+    toast: { success: () => {}, error: () => {}, warning: () => {}, info: () => {} },
+    loading: { show: () => {}, hide: () => {} },
+  }), [scope]);
+
+  const form = useDataForm({
+    schema: itemSchema,
+    scope: scope as typeof Scope[keyof typeof Scope],
+    component: noopComponent,
+    initialValues,
+  });
+
+  const handleSave = () => {
+    if (form.validate()) {
+      onSave(form.state);
+    }
+  };
+
+  return createPortal(
+    <div style={modalStyles.overlay} onClick={onCancel}>
+      <div style={modalStyles.card} onClick={(e) => e.stopPropagation()}>
+        <div style={modalStyles.title}>
+          {initialValues ? t("common.list.editItem", { defaultValue: "Edit item" }) : t("common.list.addItem", { defaultValue: "Add item" })}
+        </div>
+        <div style={modalStyles.body}>
+          <div style={{ display: "grid", gridTemplateColumns: "repeat(100, 1fr)" }}>
+            {form.fields.map((field) => {
+              if (field.proxy.hidden) return null;
+              const Renderer = getRenderer(field.config.component);
+              if (!Renderer) return null;
+              return (
+                <div key={field.name} style={{ gridColumn: `span ${field.proxy.width}` }}>
+                  <Renderer {...form.getFieldProps(field.name)} />
+                </div>
+              );
+            })}
+          </div>
+        </div>
+        <div style={modalStyles.actions}>
+          <button type="button" style={modalStyles.cancelButton} onClick={onCancel}>
+            {t("common.dialog.cancel", { defaultValue: "Cancel" })}
+          </button>
+          <button type="button" style={modalStyles.okButton} onClick={handleSave}>
+            {t("common.dialog.ok", { defaultValue: "OK" })}
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}
+
+export function ListField({ domain, name, value, config, proxy, errors, onChange, scope }: FieldRendererProps) {
   const { t } = useTranslation();
   const theme = useTheme();
   const styles = createStyles(theme);
   const [editIndex, setEditIndex] = useState<number | null>(null);
+  const [showAdd, setShowAdd] = useState(false);
   if (proxy.hidden) return null;
 
   const fieldLabel = t(`${domain}.fields.${name}`, { defaultValue: name });
   const hasError = errors.length > 0;
   const items = Array.isArray(value) ? (value as Record<string, unknown>[]) : [];
   const reorderable = config.attrs.reorderable === true;
+  const rawSchema = config.attrs.itemSchema;
+  const itemSchema = rawSchema && typeof rawSchema === 'object' && 'fields' in rawSchema && 'domain' in rawSchema
+    ? (rawSchema as SchemaProvide)
+    : undefined;
 
   const remove = (index: number) => {
     onChange(items.filter((_, i) => i !== index));
   };
 
   const add = () => {
-    onChange([...items, {}]);
+    if (itemSchema) {
+      setShowAdd(true);
+    } else {
+      onChange([...items, {}]);
+    }
   };
 
   const moveUp = (index: number) => {
@@ -39,6 +125,19 @@ export function ListField({ domain, name, value, config, proxy, errors, onChange
     onChange(next);
   };
 
+  const handleSaveNew = (values: Record<string, unknown>) => {
+    onChange([...items, values]);
+    setShowAdd(false);
+  };
+
+  const handleSaveEdit = (values: Record<string, unknown>) => {
+    if (editIndex === null) return;
+    const next = [...items];
+    next[editIndex] = values;
+    onChange(next);
+    setEditIndex(null);
+  };
+
   return (
     <div style={styles.container} {...ds(`ListField:${name}`)}>
       <label style={{ ...styles.label, ...(hasError ? styles.labelError : {}) }}>{fieldLabel}</label>
@@ -50,6 +149,9 @@ export function ListField({ domain, name, value, config, proxy, errors, onChange
               {Object.values(item).filter(Boolean).join(", ") || "—"}
             </span>
             <div style={styles.rowActions}>
+              {itemSchema && !proxy.disabled && (
+                <button type="button" style={styles.btn} onClick={() => setEditIndex(index)}>✎</button>
+              )}
               {reorderable && (
                 <>
                   <button type="button" style={styles.btn} onClick={() => moveUp(index)} disabled={proxy.disabled || index === 0}>↑</button>
@@ -71,6 +173,26 @@ export function ListField({ domain, name, value, config, proxy, errors, onChange
           <p key={i} style={styles.error}>{error}</p>
         ))}
       </div>
+
+      {showAdd && itemSchema && (
+        <ItemFormModal
+          itemSchema={itemSchema}
+          scope={scope}
+          onSave={handleSaveNew}
+          onCancel={() => setShowAdd(false)}
+        />
+      )}
+
+      {editIndex !== null && itemSchema && (
+        <ItemFormModal
+          key={editIndex}
+          itemSchema={itemSchema}
+          scope={scope}
+          initialValues={items[editIndex]}
+          onSave={handleSaveEdit}
+          onCancel={() => setEditIndex(null)}
+        />
+      )}
     </div>
   );
 }
@@ -150,5 +272,65 @@ const createStyles = (theme: Theme) => ({
     fontSize: theme.fontSize.xs,
     color: theme.colors.destructive,
     margin: 0,
+  },
+});
+
+const createModalStyles = (theme: Theme) => ({
+  overlay: {
+    position: "fixed" as const,
+    inset: 0,
+    backgroundColor: "rgba(0, 0, 0, 0.5)",
+    display: "flex",
+    justifyContent: "center",
+    alignItems: "center",
+    zIndex: 9999,
+  },
+  card: {
+    backgroundColor: theme.colors.card,
+    borderRadius: theme.borderRadius.xl,
+    padding: theme.spacing.xxl,
+    minWidth: 400,
+    maxWidth: 640,
+    maxHeight: "80vh",
+    overflow: "auto",
+    boxShadow: "0 4px 12px rgba(0, 0, 0, 0.15)",
+  },
+  title: {
+    fontSize: theme.fontSize.lg,
+    fontWeight: theme.fontWeight.semibold,
+    color: theme.colors.foreground,
+    marginBottom: theme.spacing.md,
+  },
+  body: {
+    marginBottom: theme.spacing.xl,
+  },
+  actions: {
+    display: "flex",
+    justifyContent: "flex-end",
+    gap: theme.spacing.sm,
+  },
+  cancelButton: {
+    padding: `${theme.spacing.sm}px ${theme.spacing.lg}px`,
+    borderRadius: theme.borderRadius.md,
+    minWidth: 80,
+    textAlign: "center" as const,
+    backgroundColor: theme.colors.secondary,
+    color: theme.colors.secondaryForeground,
+    fontSize: theme.fontSize.sm,
+    fontWeight: theme.fontWeight.medium,
+    border: "none",
+    cursor: "pointer",
+  },
+  okButton: {
+    padding: `${theme.spacing.sm}px ${theme.spacing.lg}px`,
+    borderRadius: theme.borderRadius.md,
+    minWidth: 80,
+    textAlign: "center" as const,
+    backgroundColor: theme.colors.primary,
+    color: theme.colors.primaryForeground,
+    fontSize: theme.fontSize.sm,
+    fontWeight: theme.fontWeight.medium,
+    border: "none",
+    cursor: "pointer",
   },
 });

--- a/packages/react-web/src/renderers/index.ts
+++ b/packages/react-web/src/renderers/index.ts
@@ -9,6 +9,8 @@ import { SelectField } from "./SelectField";
 import { MultiSelectField } from "./MultiSelectField";
 import { ListField } from "./ListField";
 import { TreeField } from "./TreeField";
+import { CurrencyField } from "./CurrencyField";
+import { FileField } from "./FileField";
 
 registerRenderers({
   text: TextField,
@@ -23,4 +25,7 @@ registerRenderers({
   multiselect: MultiSelectField,
   list: ListField,
   tree: TreeField,
+  currency: CurrencyField,
+  file: FileField,
+  image: FileField,
 });

--- a/packages/sveltekit/src/renderers/CurrencyField.svelte
+++ b/packages/sveltekit/src/renderers/CurrencyField.svelte
@@ -1,0 +1,69 @@
+<script lang="ts">
+  import { translate, hasTranslation } from '../i18n'
+
+  let { domain, name, value, config, proxy, errors, onChange, onBlur, onFocus }: {
+    domain: string
+    name: string
+    value: unknown
+    config: { attrs: Record<string, unknown> }
+    proxy: { hidden: boolean; disabled: boolean }
+    errors: string[]
+    onChange: (v: unknown) => void
+    onBlur: () => void
+    onFocus: () => void
+  } = $props()
+
+  let label = $derived(() => {
+    const key = `${domain}.fields.${name}`
+    return hasTranslation(key) ? translate(key) : name
+  })
+
+  let prefix = $derived((config.attrs.prefix as string) ?? '')
+  let precision = $derived((config.attrs.precision as number) ?? 2)
+  let step = $derived(precision > 0 ? (1 / Math.pow(10, precision)).toString() : '1')
+</script>
+
+{#if !proxy.hidden}
+  <div class="form-field" class:has-error={errors.length > 0}>
+    <label for={name}>{label()}</label>
+    <div class="currency-wrapper">
+      {#if prefix}
+        <span class="currency-prefix">{prefix}</span>
+      {/if}
+      <input
+        id={name}
+        type="number"
+        {step}
+        class:has-prefix={!!prefix}
+        value={value != null ? String(value) : ''}
+        disabled={proxy.disabled}
+        oninput={(e) => {
+          const v = e.currentTarget.value
+          onChange(v === '' ? undefined : Number(v))
+        }}
+        onblur={() => onBlur()}
+        onfocus={() => onFocus()}
+      />
+    </div>
+    {#if errors.length > 0}
+      <span class="field-error">{errors[0]}</span>
+    {/if}
+  </div>
+{/if}
+
+<style>
+  .currency-wrapper {
+    position: relative;
+    display: flex;
+    align-items: center;
+  }
+  .currency-prefix {
+    position: absolute;
+    left: 0.75rem;
+    color: var(--muted-foreground, #888);
+    pointer-events: none;
+  }
+  .has-prefix {
+    padding-left: 2.25rem;
+  }
+</style>

--- a/packages/sveltekit/src/renderers/FileField.svelte
+++ b/packages/sveltekit/src/renderers/FileField.svelte
@@ -1,0 +1,89 @@
+<script lang="ts">
+  import { translate, hasTranslation } from '../i18n'
+
+  let { domain, name, value, config, proxy, errors, onChange }: {
+    domain: string
+    name: string
+    value: unknown
+    config: { component: string; attrs: Record<string, unknown> }
+    proxy: { hidden: boolean; disabled: boolean }
+    errors: string[]
+    onChange: (v: unknown) => void
+    onBlur: () => void
+    onFocus: () => void
+  } = $props()
+
+  let label = $derived(() => {
+    const key = `${domain}.fields.${name}`
+    return hasTranslation(key) ? translate(key) : name
+  })
+
+  let accept = $derived((config.attrs.accept as string) ?? (config.component === 'image' ? 'image/*' : undefined))
+  let isImage = $derived(config.component === 'image')
+  let fileName = $derived(value instanceof File ? value.name : (value ? String(value) : ''))
+
+  let fileInput: HTMLInputElement
+
+  function handleChange(e: Event) {
+    const input = e.target as HTMLInputElement
+    const file = input.files?.[0]
+    onChange(file ?? null)
+  }
+</script>
+
+{#if !proxy.hidden}
+  <div class="form-field" class:has-error={errors.length > 0}>
+    <label>{label()}</label>
+    <div class="file-wrapper">
+      <button
+        type="button"
+        class="file-choose-btn"
+        disabled={proxy.disabled}
+        onclick={() => fileInput.click()}
+      >
+        {isImage ? 'Choose image…' : 'Choose file…'}
+      </button>
+      <span class="file-name">{fileName || 'No file selected'}</span>
+      <input
+        bind:this={fileInput}
+        type="file"
+        {accept}
+        style="display:none"
+        onchange={handleChange}
+        disabled={proxy.disabled}
+      />
+    </div>
+    {#if errors.length > 0}
+      <span class="field-error">{errors[0]}</span>
+    {/if}
+  </div>
+{/if}
+
+<style>
+  .file-wrapper {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+  .file-choose-btn {
+    white-space: nowrap;
+    padding: 0.4rem 0.75rem;
+    border: 1px solid var(--input-border, #ccc);
+    border-radius: 0.375rem;
+    background: var(--secondary, #f0f0f0);
+    color: var(--secondary-foreground, #333);
+    cursor: pointer;
+    font-size: 0.875rem;
+  }
+  .file-choose-btn:disabled {
+    cursor: default;
+    opacity: 0.6;
+  }
+  .file-name {
+    font-size: 0.875rem;
+    color: var(--muted-foreground, #888);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+</style>

--- a/packages/sveltekit/src/renderers/ListField.svelte
+++ b/packages/sveltekit/src/renderers/ListField.svelte
@@ -1,7 +1,11 @@
 <script lang="ts">
   import { translate, hasTranslation } from '../i18n'
+  import { getRenderer } from '@ybyra/svelte'
+  import { useDataForm } from '@ybyra/svelte'
+  import type { UseDataFormStore } from '@ybyra/svelte'
+  import type { SchemaProvide, ScopeValue, ComponentContract } from '@ybyra/core'
 
-  let { domain, name, value, config, proxy, errors, onChange }: {
+  let { domain, name, value, config, proxy, errors, onChange, scope }: {
     domain: string
     name: string
     value: unknown
@@ -11,6 +15,7 @@
     onChange: (v: unknown) => void
     onBlur: () => void
     onFocus: () => void
+    scope: string
   } = $props()
 
   let label = $derived(() => {
@@ -20,13 +25,83 @@
 
   let items = $derived(Array.isArray(value) ? (value as Record<string, unknown>[]) : [])
   let reorderable = $derived(config.attrs.reorderable === true)
+  let itemSchema = $derived(() => {
+    const raw = config.attrs.itemSchema
+    return raw && typeof raw === 'object' && 'fields' in raw && 'domain' in raw
+      ? (raw as SchemaProvide)
+      : undefined
+  })
+
+  let showAdd = $state(false)
+  let editIndex = $state<number | null>(null)
+
+  // Sub-form store (Svelte Readable)
+  let formStore = $state<UseDataFormStore | null>(null)
+  // Reactive subscription to the store value
+  let form = $derived(formStore ? $formStore : null)
+
+  const noopComponent: ComponentContract = {
+    scope: scope as ScopeValue,
+    scopes: {} as Record<string, { path: string }>,
+    reload: () => {},
+    navigator: { push: () => {}, back: () => {}, replace: () => {} },
+    dialog: { confirm: async () => true, alert: async () => {} },
+    toast: { success: () => {}, error: () => {}, warning: () => {}, info: () => {} },
+    loading: { show: () => {}, hide: () => {} },
+  }
+
+  function openAdd() {
+    const schema = itemSchema()
+    if (schema) {
+      formStore = useDataForm({
+        schema,
+        scope: scope as ScopeValue,
+        component: noopComponent,
+      })
+      showAdd = true
+    } else {
+      onChange([...items, {}])
+    }
+  }
+
+  function openEdit(index: number) {
+    const schema = itemSchema()
+    if (!schema) return
+    formStore = useDataForm({
+      schema,
+      scope: scope as ScopeValue,
+      component: noopComponent,
+      initialValues: items[index],
+    })
+    editIndex = index
+  }
+
+  function saveNew() {
+    if (!form) return
+    if (formStore!.validate()) {
+      onChange([...$state.snapshot(items), { ...form.state }])
+      cancelModal()
+    }
+  }
+
+  function saveEdit() {
+    if (!form || editIndex === null) return
+    if (formStore!.validate()) {
+      const next = [...$state.snapshot(items)]
+      next[editIndex] = { ...form.state }
+      onChange(next)
+      cancelModal()
+    }
+  }
+
+  function cancelModal() {
+    showAdd = false
+    editIndex = null
+    formStore = null
+  }
 
   function remove(index: number) {
     onChange(items.filter((_, i) => i !== index))
-  }
-
-  function add() {
-    onChange([...items, {}])
   }
 
   function moveUp(index: number) {
@@ -42,6 +117,8 @@
     [next[index], next[index + 1]] = [next[index + 1], next[index]]
     onChange(next)
   }
+
+  let modalOpen = $derived(showAdd || editIndex !== null)
 </script>
 
 {#if !proxy.hidden}
@@ -55,6 +132,9 @@
             {Object.values(item).filter(Boolean).join(', ') || '—'}
           </span>
           <div class="row-actions">
+            {#if itemSchema() && !proxy.disabled}
+              <button type="button" onclick={() => openEdit(index)}>✎</button>
+            {/if}
             {#if reorderable}
               <button type="button" onclick={() => moveUp(index)} disabled={proxy.disabled || index === 0}>↑</button>
               <button type="button" onclick={() => moveDown(index)} disabled={proxy.disabled || index >= items.length - 1}>↓</button>
@@ -67,10 +147,90 @@
       {/each}
     </div>
     {#if !proxy.disabled}
-      <button type="button" class="add-btn" onclick={add}>+</button>
+      <button type="button" class="add-btn" onclick={openAdd}>+</button>
     {/if}
     {#if errors.length > 0}
       <span class="field-error">{errors[0]}</span>
     {/if}
   </div>
 {/if}
+
+{#if modalOpen && form}
+  <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
+  <div class="modal-overlay" role="dialog" tabindex="-1" onclick={cancelModal} onkeydown={(e) => e.key === 'Escape' && cancelModal()}>
+    <div class="modal-card" onclick={(e) => e.stopPropagation()}>
+      <div class="modal-title">
+        {editIndex !== null
+          ? (hasTranslation('common.list.editItem') ? translate('common.list.editItem') : 'Edit item')
+          : (hasTranslation('common.list.addItem') ? translate('common.list.addItem') : 'Add item')}
+      </div>
+      <div class="modal-body">
+        {#each form.fields as field (field.name)}
+          {#if !field.proxy.hidden}
+            {@const renderer = getRenderer(field.config.component)}
+            {#if renderer}
+              <svelte:component this={renderer} {...form.getFieldProps(field.name)} />
+            {/if}
+          {/if}
+        {/each}
+      </div>
+      <div class="modal-actions">
+        <button type="button" class="modal-cancel" onclick={cancelModal}>{hasTranslation('common.dialog.cancel') ? translate('common.dialog.cancel') : 'Cancel'}</button>
+        <button type="button" class="modal-ok" onclick={editIndex !== null ? saveEdit : saveNew}>{hasTranslation('common.dialog.ok') ? translate('common.dialog.ok') : 'OK'}</button>
+      </div>
+    </div>
+  </div>
+{/if}
+
+<style>
+  .modal-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.5);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 9999;
+  }
+  .modal-card {
+    background: var(--card, white);
+    border-radius: 0.75rem;
+    padding: 1.5rem;
+    min-width: 400px;
+    max-width: 640px;
+    max-height: 80vh;
+    overflow: auto;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  }
+  .modal-title {
+    font-size: 1.125rem;
+    font-weight: 600;
+    margin-bottom: 1rem;
+  }
+  .modal-body {
+    margin-bottom: 1.5rem;
+  }
+  .modal-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.5rem;
+  }
+  .modal-cancel, .modal-ok {
+    padding: 0.5rem 1rem;
+    border-radius: 0.375rem;
+    border: none;
+    cursor: pointer;
+    font-size: 0.875rem;
+    font-weight: 500;
+    min-width: 80px;
+    text-align: center;
+  }
+  .modal-cancel {
+    background: var(--secondary, #f0f0f0);
+    color: var(--secondary-foreground, #333);
+  }
+  .modal-ok {
+    background: var(--primary, #3b82f6);
+    color: var(--primary-foreground, white);
+  }
+</style>

--- a/packages/sveltekit/src/renderers/index.ts
+++ b/packages/sveltekit/src/renderers/index.ts
@@ -9,6 +9,8 @@ import SelectField from './SelectField.svelte'
 import MultiSelectField from './MultiSelectField.svelte'
 import ListField from './ListField.svelte'
 import TreeField from './TreeField.svelte'
+import CurrencyField from './CurrencyField.svelte'
+import FileField from './FileField.svelte'
 
 registerRenderers({
   text: TextField,
@@ -23,4 +25,7 @@ registerRenderers({
   multiselect: MultiSelectField,
   list: ListField,
   tree: TreeField,
+  currency: CurrencyField,
+  file: FileField,
+  image: FileField,
 })

--- a/packages/vue-quasar/src/renderers/CurrencyField.vue
+++ b/packages/vue-quasar/src/renderers/CurrencyField.vue
@@ -1,0 +1,37 @@
+<template>
+  <q-input
+    v-if="!props.proxy.hidden"
+    :model-value="props.value != null ? String(props.value) : ''"
+    :label="label"
+    :prefix="prefix"
+    :disable="props.proxy.disabled"
+    :error="props.errors.length > 0"
+    :error-message="props.errors[0]"
+    :step="step"
+    type="number"
+    outlined
+    dense
+    @update:model-value="props.onChange($event === '' ? undefined : Number($event))"
+    @blur="props.onBlur()"
+    @focus="props.onFocus()"
+  />
+</template>
+
+<script setup lang="ts">
+import { QInput } from 'quasar'
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import type { FieldRendererProps } from '@ybyra/vue'
+
+const props = defineProps<FieldRendererProps>()
+const { t, te } = useI18n()
+
+const label = computed(() => {
+  const key = `${props.domain}.fields.${props.name}`
+  return te(key) ? t(key) : props.name
+})
+
+const prefix = computed(() => (props.config.attrs.prefix as string) ?? '')
+const precision = computed(() => (props.config.attrs.precision as number) ?? 2)
+const step = computed(() => precision.value > 0 ? (1 / Math.pow(10, precision.value)).toString() : '1')
+</script>

--- a/packages/vue-quasar/src/renderers/FileField.vue
+++ b/packages/vue-quasar/src/renderers/FileField.vue
@@ -1,0 +1,54 @@
+<template>
+  <div v-if="!props.proxy.hidden" class="file-field">
+    <label class="file-label">{{ label }}</label>
+    <div class="row items-center q-gutter-sm">
+      <q-btn
+        outline
+        dense
+        :disable="props.proxy.disabled"
+        :label="isImage ? 'Choose image…' : 'Choose file…'"
+        @click="fileInput?.click()"
+      />
+      <span class="text-caption text-grey">{{ fileName || 'No file selected' }}</span>
+      <input
+        ref="fileInput"
+        type="file"
+        :accept="accept"
+        style="display: none"
+        @change="handleChange"
+      />
+    </div>
+    <div v-if="props.errors.length > 0" class="text-negative text-caption q-mt-xs">{{ props.errors[0] }}</div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { QBtn } from 'quasar'
+import { computed, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+import type { FieldRendererProps } from '@ybyra/vue'
+
+const props = defineProps<FieldRendererProps>()
+const { t, te } = useI18n()
+
+const fileInput = ref<HTMLInputElement>()
+
+const label = computed(() => {
+  const key = `${props.domain}.fields.${props.name}`
+  return te(key) ? t(key) : props.name
+})
+
+const accept = computed(() => (props.config.attrs.accept as string) ?? (props.config.component === 'image' ? 'image/*' : undefined))
+const isImage = computed(() => props.config.component === 'image')
+const fileName = computed(() => {
+  const v = props.value
+  if (v instanceof File) return v.name
+  return v ? String(v) : ''
+})
+
+function handleChange(e: Event) {
+  const input = e.target as HTMLInputElement
+  const file = input.files?.[0]
+  props.onChange(file ?? null)
+}
+</script>

--- a/packages/vue-quasar/src/renderers/ListField.vue
+++ b/packages/vue-quasar/src/renderers/ListField.vue
@@ -11,6 +11,7 @@
         </q-item-section>
         <q-item-section side>
           <div class="row no-wrap q-gutter-xs">
+            <q-btn v-if="itemSchema && !props.proxy.disabled" flat dense icon="edit" size="sm" @click="openEdit(index)" />
             <template v-if="reorderable">
               <q-btn flat dense icon="arrow_upward" size="sm" :disable="props.proxy.disabled || index === 0" @click="moveUp(index)" />
               <q-btn flat dense icon="arrow_downward" size="sm" :disable="props.proxy.disabled || index >= items.length - 1" @click="moveDown(index)" />
@@ -20,16 +21,28 @@
         </q-item-section>
       </q-item>
     </q-list>
-    <q-btn v-if="!props.proxy.disabled" flat dense icon="add" class="full-width q-mt-xs" @click="add" />
+    <q-btn v-if="!props.proxy.disabled" flat dense icon="add" class="full-width q-mt-xs" @click="openAdd" />
     <div v-if="props.errors.length > 0" class="text-negative text-caption q-mt-xs">{{ props.errors[0] }}</div>
   </div>
+
+  <ListItemFormModal
+    v-if="modalOpen && itemSchema"
+    :key="modalKey"
+    :item-schema="itemSchema"
+    :scope="props.scope"
+    :initial-values="editIndex !== null ? items[editIndex] : undefined"
+    @save="saveModal"
+    @cancel="cancelModal"
+  />
 </template>
 
 <script setup lang="ts">
 import { QList, QItem, QItemSection, QBtn } from 'quasar'
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import type { FieldRendererProps } from '@ybyra/vue'
+import type { SchemaProvide } from '@ybyra/core'
+import ListItemFormModal from './ListItemFormModal.vue'
 
 const props = defineProps<FieldRendererProps>()
 const { t, te } = useI18n()
@@ -41,13 +54,52 @@ const label = computed(() => {
 
 const items = computed(() => Array.isArray(props.value) ? (props.value as Record<string, unknown>[]) : [])
 const reorderable = computed(() => props.config.attrs.reorderable === true)
+const itemSchema = computed(() => {
+  const raw = props.config.attrs.itemSchema
+  return raw && typeof raw === 'object' && 'fields' in raw && 'domain' in raw
+    ? (raw as SchemaProvide)
+    : undefined
+})
+
+const modalOpen = ref(false)
+const editIndex = ref<number | null>(null)
+const modalKey = ref(0)
+
+function openAdd() {
+  if (itemSchema.value) {
+    editIndex.value = null
+    modalKey.value++
+    modalOpen.value = true
+  } else {
+    props.onChange([...items.value, {}])
+  }
+}
+
+function openEdit(index: number) {
+  if (!itemSchema.value) return
+  editIndex.value = index
+  modalKey.value++
+  modalOpen.value = true
+}
+
+function saveModal(values: Record<string, unknown>) {
+  if (editIndex.value !== null) {
+    const next = [...items.value]
+    next[editIndex.value] = values
+    props.onChange(next)
+  } else {
+    props.onChange([...items.value, values])
+  }
+  cancelModal()
+}
+
+function cancelModal() {
+  modalOpen.value = false
+  editIndex.value = null
+}
 
 function remove(index: number) {
   props.onChange(items.value.filter((_, i) => i !== index))
-}
-
-function add() {
-  props.onChange([...items.value, {}])
 }
 
 function moveUp(index: number) {

--- a/packages/vue-quasar/src/renderers/ListItemFormModal.vue
+++ b/packages/vue-quasar/src/renderers/ListItemFormModal.vue
@@ -1,0 +1,66 @@
+<template>
+  <q-dialog :model-value="true" persistent @update:model-value="$emit('cancel')">
+    <q-card style="min-width: 400px; max-width: 640px">
+      <q-card-section>
+        <div class="text-h6">{{ props.initialValues ? t('common.list.editItem', 'Edit item') : t('common.list.addItem', 'Add item') }}</div>
+      </q-card-section>
+      <q-card-section>
+        <template v-for="field in form.fields" :key="field.name">
+          <component
+            v-if="!field.proxy.hidden"
+            :is="getFieldRenderer(field.config.component)"
+            v-bind="form.getFieldProps(field.name)"
+          />
+        </template>
+      </q-card-section>
+      <q-card-actions align="right">
+        <q-btn flat :label="t('common.dialog.cancel', 'Cancel')" @click="$emit('cancel')" />
+        <q-btn flat :label="t('common.dialog.ok', 'OK')" color="primary" @click="handleSave" />
+      </q-card-actions>
+    </q-card>
+  </q-dialog>
+</template>
+
+<script setup lang="ts">
+import { QDialog, QCard, QCardSection, QCardActions, QBtn } from 'quasar'
+import { useI18n } from 'vue-i18n'
+import { useDataForm, getRenderer as getFieldRenderer } from '@ybyra/vue'
+import type { SchemaProvide, ScopeValue, ComponentContract } from '@ybyra/core'
+
+const props = defineProps<{
+  itemSchema: SchemaProvide
+  scope: string
+  initialValues?: Record<string, unknown>
+}>()
+
+const emit = defineEmits<{
+  save: [values: Record<string, unknown>]
+  cancel: []
+}>()
+
+const { t } = useI18n()
+
+const noopComponent: ComponentContract = {
+  scope: props.scope as ScopeValue,
+  scopes: {} as Record<string, { path: string }>,
+  reload: () => {},
+  navigator: { push: () => {}, back: () => {}, replace: () => {} },
+  dialog: { confirm: async () => true, alert: async () => {} },
+  toast: { success: () => {}, error: () => {}, warning: () => {}, info: () => {} },
+  loading: { show: () => {}, hide: () => {} },
+}
+
+// useDataForm runs in setup context — onMounted works correctly
+const form = useDataForm({
+  schema: props.itemSchema,
+  scope: props.scope as ScopeValue,
+  component: noopComponent,
+  initialValues: props.initialValues,
+})
+
+function handleSave() {
+  if (form.validate()) {
+    emit('save', { ...form.state })
+  }
+}
+</script>

--- a/packages/vue-quasar/src/renderers/index.ts
+++ b/packages/vue-quasar/src/renderers/index.ts
@@ -9,6 +9,8 @@ import SelectField from './SelectField.vue'
 import MultiSelectField from './MultiSelectField.vue'
 import ListField from './ListField.vue'
 import TreeField from './TreeField.vue'
+import CurrencyField from './CurrencyField.vue'
+import FileField from './FileField.vue'
 
 registerRenderers({
   text: TextField,
@@ -23,4 +25,7 @@ registerRenderers({
   multiselect: MultiSelectField,
   list: ListField,
   tree: TreeField,
+  currency: CurrencyField,
+  file: FileField,
+  image: FileField,
 })


### PR DESCRIPTION
## Summary

- Add `CurrencyField` and `FileField` renderers across all 4 frameworks (react-web, react-native, sveltekit, vue-quasar), closing the gap where core field definitions existed but had no renderer
- Add mock data filler generators for `password`, `textarea`, `time`, `select`, and `multiselect` field types
- Upgrade all 4 `ListField` renderers with modal-based nested form editing when `itemSchema` is defined — uses `useDataForm` + `getRenderer` to render a full sub-form inside a modal dialog
- Change `ListFieldDefinition.itemSchema()` to store `SchemaProvide` (via `.provide()`) instead of a raw `SchemaDefinition`, so renderers can consume it directly

## Details

### New renderers (9 files)
| Renderer | react-web | react-native | sveltekit | vue-quasar |
|----------|-----------|--------------|-----------|------------|
| `CurrencyField` | ✅ prefix + precision | ✅ decimal-pad keyboard | ✅ | ✅ q-input prefix |
| `FileField` | ✅ hidden input + preview | ⚠️ placeholder (no native picker yet) | ✅ | ✅ |

All registered as `currency`, `file`, and `image` in each framework's `renderers/index.ts`.

### Filler generators (`@ybyra/core`)
| Component | Generator |
|-----------|-----------|
| `text` (password kind) | `faker.internet.password()` |
| `textarea` | `faker.lorem.paragraph()` |
| `time` | Random `HH:MM` string |
| `select` | Random pick from `config.attrs.options` |
| `multiselect` | Random 1–3 item subset from options |
| `file` / `image` | Returns `undefined` (skipped in output) |

### ListField sub-schema modal
When `list().itemSchema(schema)` is defined, the ListField renderer now:
- Shows an **✎ edit button** per row
- Opens a **modal dialog** with nested form fields on Add/Edit
- Uses `useDataForm` for full validation, state management, and proxy resolution
- Validates before save, discards on cancel
- Falls back to the original behavior (append `{}`) when no `itemSchema` is defined

### Breaking change
`ListFieldDefinition.itemSchema(schema)` now calls `schema.provide()` before storing in `config.attrs.itemSchema`. This means consumers that previously read the raw `SchemaDefinition` from attrs will now get a `SchemaProvide` object instead. No existing code in the repo relied on the old behavior.

## Known limitations
- React Native `FileField` is a UI placeholder — needs `expo-document-picker` integration for actual file selection
- No `list`/`tree` filler generators yet (consistent with `file`/`image`)
- No renderer-level test coverage for the new components

## Test plan
- [x] `@ybyra/core` — 83 tests pass (includes 7 new filler tests)
- [x] `@ybyra/react` — 79 tests pass
- [x] `@ybyra/core` build succeeds (tsup + DTS)
- [ ] Manual: verify CurrencyField renders with prefix in react-web playground
- [ ] Manual: verify ListField modal opens/saves/cancels with itemSchema in each framework
- [ ] Manual: verify FileField file selection works in react-web


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added currency field renderer with optional prefix and configurable precision.
  * Added file/image field selector with file picker UI.
  * Enhanced list fields with modal-based item editing and creation.
  * Added support for textarea, time, select, multiselect, and password field types with automatic data generation.

* **Tests**
  * Expanded filler test coverage for new field types and option-based behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->